### PR TITLE
The RadialGradient from react-native-svg expects strings not numbers

### DIFF
--- a/src/RadialGradient.tsx
+++ b/src/RadialGradient.tsx
@@ -7,7 +7,7 @@ import Svg, {
 } from 'react-native-svg';
 import {Color} from './types';
 
-export const RadialGradient = ({ colorList, x, y, rx, ry }: {  colorList: Color[]; x: number; y: number; rx: number; ry: number}) => {
+export const RadialGradient = ({ colorList, x, y, rx, ry }: {  colorList: Color[]; x: string; y: string; rx: string; ry: string}) => {
   return (
     <Svg height="100%" width="100%">
       <Defs>


### PR DESCRIPTION
Thanks for the recent addition of typescript types.

I tried out this release, and it looks like x/y/rx/ry should actually be strings, according to the react-native-svg types.