### PR TITLE
Fix onLayout gradient not being updated

### DIFF
--- a/src/RadialGradient.tsx
+++ b/src/RadialGradient.tsx
@@ -8,11 +8,12 @@ import Svg, {
 import {Color} from './types';
 
 export const RadialGradient = ({ colorList, x, y, rx, ry }: {  colorList: Color[]; x: string; y: string; rx: string; ry: string}) => {
+  const uniqueId = React.useMemo(() => `grad-${Math.random().toString(32)}`, []);
   return (
     <Svg height="100%" width="100%">
       <Defs>
         <SVGRadialGradient
-          id="grad"
+          id={uniqueId}
           cx={x}
           cy={y}
           rx={rx}
@@ -29,7 +30,7 @@ export const RadialGradient = ({ colorList, x, y, rx, ry }: {  colorList: Color[
           ))}
         </SVGRadialGradient>
       </Defs>
-      <Rect x="0" y="0" width="100%" height="100%" fill="url(#grad)" />
+      <Rect x="0" y="0" width="100%" height="100%" fill={`url(#${uniqueId})`} />
     </Svg>
   );
 };


### PR DESCRIPTION
We have a gradient in position absolute next to the `children`. When children changes, gradient was not being updated due to sharing ID of the previous definition. This fixes the issue.